### PR TITLE
default-trusted-users: Kyrias -> demize

### DIFF
--- a/lib/aurto/default-trusted-users.txt
+++ b/lib/aurto/default-trusted-users.txt
@@ -31,7 +31,7 @@ jelly
 jleclanche
 jsteel
 keenerd
-Kyrias
+demize
 Lordheavy
 mtorromeo
 Muflone


### PR DESCRIPTION
The username changed quite a while ago, having this in is borderline dangerous as anyone could've registered the wrong name and be implicitly trusted