### PR TITLE
Require wheel group to aurto init

### DIFF
--- a/lib/aurto/install
+++ b/lib/aurto/install
@@ -13,6 +13,15 @@ source "$lib_dir/shared-functions"
 # Initialise the aurto repo, trusted-users list & systemd timers
 init() {
   echo "aurto: Initialising for user: $user"
+
+  # Ensure $user is in `wheel`. This is required for update-aurto passwordless sudo to work.
+  groups=$(groups "$user")
+  if [[ $groups != "wheel "* ]] && [[ $groups != *" wheel "* ]] && [[ $groups != *" wheel" ]]; then
+    echo -ne "aurto: $(red user is not in group \`wheel\`), this is required for auto updating." >&2
+    echo -e " Add with: $(cyan usermod -aG wheel "$user")" >&2
+    exit 2
+  fi
+
   echo "$user" > /usr/lib/aurto/user
   chmod 700 /usr/lib/aurto/user
 
@@ -28,8 +37,6 @@ init() {
   systemctl enable --now /usr/lib/systemd/system/check-aurto-git-trigger.timer
   systemctl enable --now /usr/lib/systemd/system/update-aurto.timer
   systemctl enable /usr/lib/systemd/system/update-aurto-startup.timer
-
-  echo "aurto: Passwordless usage available for \`wheel\` group"
 
   echo "\"Include = /etc/pacman.d/aurto\" must be added to /etc/pacman.conf to enable the aurto repo"
   if test -t 1; then

--- a/trust-check/Cargo.lock
+++ b/trust-check/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.39+curl-7.74.0"
+version = "0.4.40+curl-7.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a8ce861e7b68a0b394e814d7ee9f1b2750ff8bd10372c6ad3bacc10e86f874"
+checksum = "2ffafc1c35958318bd7fdd0582995ce4c72f4f461a8e70499ccee83a619fd562"
 dependencies = [
  "cc",
  "libc",
@@ -62,9 +62,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
 
 [[package]]
 name = "libz-sys"


### PR DESCRIPTION
If a user is not in the `wheel` group when running `aurto init` it will fail.

```
$ aurto init
aurto: Initialising for user: alex
aurto: user is not in group `wheel`, this is required for auto updating. Add with: usermod -aG wheel alex
```

Resolves #56 