### PR TITLE
Add support for docker with README install instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Create and Publish a Docker image
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.6.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4.1.1
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM archlinux:base-devel AS build
 
 # Setup sudo user & install dependencies
-RUN pacman -Sy --noconfirm git pacutils perl-json-xs devtools pacman-contrib ninja cargo && \
+RUN pacman -Syu --noconfirm git pacutils perl-json-xs devtools pacman-contrib ninja cargo && \
     echo '%wheel ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers && \
     useradd --uid 1000 --shell /bin/bash --groups wheel --create-home build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+FROM archlinux:latest
+
+ENV USER_ID="1002" \
+    TZ="Europe/Madrid" \
+    USER=aurto
+
+WORKDIR /
+
+# Remove unnecessary units
+RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
+  /etc/systemd/system/*.wants/* \
+  /lib/systemd/system/local-fs.target.wants/* \
+  /lib/systemd/system/sockets.target.wants/*udev* \
+  /lib/systemd/system/sockets.target.wants/*initctl* \
+  /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* \
+  /lib/systemd/system/systemd-update-utmp*
+
+# Install dependencies and setup sudo user
+RUN pacman -Syu --noconfirm base-devel sudo && \
+    echo '%wheel ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers && \
+    useradd --uid ${USER_ID} --shell /bin/bash --groups wheel --create-home aurto
+
+WORKDIR /tmp
+
+RUN mkdir gosu; \
+    cd gosu; \
+    curl -L https://github.com/tianon/gosu/releases/latest/download/gosu-amd64 > gosu && \
+    curl -L https://github.com/tianon/gosu/releases/latest/download/gosu-amd64.asc > gosu.asc && \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
+    gpg --batch --verify gosu.asc gosu && \
+    mv gosu /usr/local/bin/gosu && \
+    chmod +x /usr/local/bin/gosu && \
+    cd .. && \
+
+    curl -L https://aur.archlinux.org/cgit/aur.git/snapshot/aurutils.tar.gz | tar xz && \
+    chown -R aurto aurutils && \
+    cd aurutils && \
+    gpg --recv-keys DBE7D3DD8C81D58D0A13D0E76BC26A17B9B7018A && \
+    gosu aurto makepkg -srci --noconfirm && \
+    cd .. && \
+
+    # Install aurto
+    curl -L https://aur.archlinux.org/cgit/aur.git/snapshot/aurto.tar.gz | tar xz && \
+    chown -R aurto aurto && \
+    cd aurto && \
+    sed -i -e 's/systemctl enable --now/systemctl enable/g' aurto.install && \
+    gosu aurto makepkg -srci --noconfirm && \
+
+    # Cleanup
+    rm -r /tmp/* && \
+    pacman -Sy && \
+    pacman -Rs base-devel --noconfirm && \
+
+    # Set timezone
+    ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
+
+WORKDIR /home/aurto
+
+VOLUME ["/tmp", "/run", "/run/lock", "/etc/aurto", "/var/cache/pacman/aurto"]
+
+CMD [ "/lib/systemd/systemd", "log-level=info", "unit=sysinit.target" ]

--- a/README.md
+++ b/README.md
@@ -37,35 +37,6 @@ Recommended: Add **aurto** to the 'aurto' repo to provide self updates.
 aurto add aurto
 ```
 
-# Install with docker
-After installing docker on your machine, run this command to create the container:
-```sh
-docker run -d --name aurto-docker \
-  --privileged --cap-add SYS_ADMIN --security-opt seccomp=unconfined \
-  --cgroup-parent=docker.slice --cgroupns private \
-  --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
-  -v aurto_db:/var/cache/pacman/aurto \
-  -v aurto_config:/etc/aurto \
-  -e TZ=Europe/Madrid \   # Change timezone to be the same as your machine
-  ghcr.io/alexheretic/aurto:main
-```
-
-Then running the commands like a normal installation, first initialise the 'aurto' repo & systemd timers.
-```sh
-docker exec -it --user aurto aurto-docker aurto init
-```
-
-Recommended: Add **aurto** to the 'aurto' repo to provide self updates.
-```sh
-docker exec -it --user aurto aurto-docker aurto add aurto
-```
-
-Also recommended: Add an alias to .bashrc so you only have to write aurto instead of the full docker command.
-
-```sh
-alias aurto="docker exec -it --user aurto aurto-docker aurto"
-```
-
 # Usage
 You add aur packages to your local 'aurto' repo. This is different to installing them.
 ```sh
@@ -118,6 +89,11 @@ Remove `/etc/aurto/trusted-users` to trust everyone.
 # Config
 **aurto** builds packages in a chroot using `/etc/aurto/makepkg-chroot.conf` &  `/etc/aurto/pacman-chroot.conf`.
 These can be customized in the same way as the main _makepkg.conf, pacman.conf_, for example to change compression. 
+
+# Running on docker
+**aurto** can also be ran on docker to allow for installation on non Arch distros for hosting a aur repo, etc.
+
+You can find the documentation on how to install it [here](./dockerREADME.md).
 
 # Limitations & Security
 **aurto** automatically builds and regularly re-builds updated remote code from the aur.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,35 @@ Recommended: Add **aurto** to the 'aurto' repo to provide self updates.
 aurto add aurto
 ```
 
+# Install with docker
+After installing docker on your machine, run this command to create the container:
+```sh
+docker run -d --name aurto-docker \
+  --privileged --cap-add SYS_ADMIN --security-opt seccomp=unconfined \
+  --cgroup-parent=docker.slice --cgroupns private \
+  --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
+  -v aurto_db:/var/cache/pacman/aurto \
+  -v aurto_config:/etc/aurto \
+  -e TZ=Europe/Madrid \   # Change timezone to be the same as your machine
+  ghcr.io/alexheretic/aurto:main
+```
+
+Then running the commands like a normal installation, first initialise the 'aurto' repo & systemd timers.
+```sh
+docker exec -it --user aurto aurto-docker aurto init
+```
+
+Recommended: Add **aurto** to the 'aurto' repo to provide self updates.
+```sh
+docker exec -it --user aurto aurto-docker aurto add aurto
+```
+
+Also recommended: Add an alias to .bashrc so you only have to write aurto instead of the full docker command.
+
+```sh
+alias aurto="docker exec -it --user aurto aurto-docker aurto"
+```
+
 # Usage
 You add aur packages to your local 'aurto' repo. This is different to installing them.
 ```sh

--- a/dockerREADME.md
+++ b/dockerREADME.md
@@ -1,0 +1,30 @@
+# aurto with docker
+
+After installing docker on your machine, run this command to create the container:
+```sh
+docker run -d --name aurto-docker \
+  --privileged --cap-add SYS_ADMIN --security-opt seccomp=unconfined \
+  --cgroup-parent=docker.slice --cgroupns private \
+  --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
+  -v aurto_db:/var/cache/pacman/aurto \
+  -v aurto_config:/etc/aurto \
+  ghcr.io/alexheretic/aurto:master
+```
+
+> Make sure to replace **aurto_db** and **aurto_config** with an actual path if you don't want it to store the pacman repo and config files in a docker volume
+
+Then running the commands like a normal installation, first initialise the 'aurto' repo & systemd timers.
+```sh
+docker exec -it --user aurto aurto-docker aurto init
+```
+
+Recommended: Add **aurto** to the 'aurto' repo to provide self updates.
+```sh
+docker exec -it --user aurto aurto-docker aurto add aurto
+```
+
+Also recommended: Add an alias to .bashrc so you only have to write aurto instead of the full docker command.
+
+```sh
+alias aurto="docker exec -it --user aurto aurto-docker aurto"
+```


### PR DESCRIPTION
> This is a push request that I submitted a couple of weeks ago, but then closed due to spotting a bug, which should now be resolved

This push requests adds a Dockerfile to add support for running aurto via a docker container, with included install instructions and a workflow to automatically build a new image every time a push is commited to the master branch and uploades it to the GitHub package registry.

Sidenote: the Dockerfile builds aurto from the AUR, which may make it slightly behind github commits at times.