### PR TITLE
Update makepkg & pacman config inline with upstream v7

### DIFF
--- a/conf/makepkg-chroot.conf
+++ b/conf/makepkg-chroot.conf
@@ -5,7 +5,6 @@
 # /etc/aurto/makepkg-chroot.conf
 #
 # Used in aurto chroot builds
-# /etc/makepkg.conf
 #
 
 #########################################################################
@@ -51,13 +50,25 @@ CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
 LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
          -Wl,-z,pack-relative-relocs"
 LTOFLAGS="-flto=auto"
-RUSTFLAGS="-Cforce-frame-pointers=yes"
 #-- Make Flags: change this for DistCC/SMP systems
 #MAKEFLAGS="-j2"
 #-- Debugging flags
 DEBUG_CFLAGS="-g"
 DEBUG_CXXFLAGS="$DEBUG_CFLAGS"
+
+#########################################################################
+# RUST LANGUAGE SUPPORT
+#########################################################################
+
+# Flags used for the Rust compiler, similar in spirit to CFLAGS. Read
+# linkman:rustc[1] for more details on the available flags.
+RUSTFLAGS="-Cforce-frame-pointers=yes"
+
+# Additional compiler flags appended to `RUSTFLAGS` for use in debugging.
+# Usually this would include: ``-C debuginfo=2''. Read linkman:rustc[1] for
+# more details on the available flags.
 DEBUG_RUSTFLAGS="-C debuginfo=2"
+
 
 #########################################################################
 # BUILD ENVIRONMENT
@@ -147,7 +158,7 @@ LIB_DIRS=('lib:usr/lib' 'lib32:usr/lib32')
 COMPRESSGZ=(gzip -c -f -n)
 COMPRESSBZ2=(bzip2 -c -f)
 COMPRESSXZ=(xz -c -z -)
-COMPRESSZST=(zstd -c -T0 --ultra -20 -)
+COMPRESSZST=(zstd -c -T0 -)
 COMPRESSLRZ=(lrzip -q)
 COMPRESSLZO=(lzop -q)
 COMPRESSZ=(compress -c -f)

--- a/conf/pacman-chroot.conf
+++ b/conf/pacman-chroot.conf
@@ -2,7 +2,6 @@
 # /etc/aurto/pacman-chroot.conf
 #
 # Used in aurto chroot builds
-# /etc/pacman.conf
 #
 # See the pacman.conf(5) manpage for option and repository directives
 
@@ -38,7 +37,9 @@ Architecture = auto
 ## Note: We cannot check disk space from within a chroot environment
 #CheckSpace
 #VerbosePkgLists
-#ParallelDownloads = 5
+ParallelDownloads = 5
+DownloadUser = alpm
+#DisableSandbox
 
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.
@@ -94,7 +95,5 @@ Include = /etc/pacman.d/mirrorlist
 [multilib]
 Include = /etc/pacman.d/mirrorlist
 
-# Aurto custom package repository
-[aurto]
-SigLevel = Never
-Server = file:///var/cache/pacman/aurto
+# aurto repo
+Include = /etc/pacman.d/aurto

--- a/conf/pacman-chroot.conf
+++ b/conf/pacman-chroot.conf
@@ -39,7 +39,8 @@ Architecture = auto
 #VerbosePkgLists
 ParallelDownloads = 5
 DownloadUser = alpm
-#DisableSandbox
+## Note: sandbox causes "error: restricting filesystem access failed because landlock is not supported by the kernel!"
+DisableSandbox
 
 # By default, pacman accepts packages signed by keys that its local keyring
 # trusts (see pacman-key and its man page), as well as unsigned packages.

--- a/conf/pacman-chroot.conf
+++ b/conf/pacman-chroot.conf
@@ -95,5 +95,6 @@ Include = /etc/pacman.d/mirrorlist
 [multilib]
 Include = /etc/pacman.d/mirrorlist
 
-# aurto repo
-Include = /etc/pacman.d/aurto
+[aurto]
+SigLevel = Never
+Server = file:///var/cache/pacman/aurto

--- a/makelocalaur.PKGBUILD
+++ b/makelocalaur.PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=aurto
 pkgver=###VERSION
 pkgrel=999
-pkgdesc="A simple aur tool for managing a local 'aurto' repository"
+pkgdesc="An AUR tool for managing an auto-updating local 'aurto' package repository using aurutils."
 arch=('x86_64' 'aarch64' 'armv7h')
 url="https://github.com/alexheretic/aurto"
 license=('MIT')
@@ -15,10 +15,13 @@ depends=('aurutils'
          'curl'
          'less'
          'sudo'
+         'zstd'
          'ninja')
 optdepends=()
 makedepends=('cargo')
 install="aurto.install"
+# ring doesn't build with lto enabled: https://github.com/briansmith/ring/issues/1444
+options=(!lto)
 source=("aurto-git.tar.gz")
 sha256sums=('eb94c0a2920ddea570621da7326f3d60c30401e8c42073b5b3ed3b1216c1ce4b')
 backup=('usr/lib/systemd/system/check-aurto-git-trigger.timer'

--- a/trust-check/Cargo.lock
+++ b/trust-check/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "percent-encoding"

--- a/trust-check/Cargo.lock
+++ b/trust-check/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "percent-encoding"
@@ -291,9 +291,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -341,9 +341,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.5"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]


### PR DESCRIPTION
* Add v7 pacman conf defaults, including `DownloadUser = alpm`
* Remove devtools zstd compression defaults
* Enable `ParallelDownloads = 5` by default as it is just better
* Include "RUST LANGUAGE SUPPORT" section directly as I'm not sure exactly how "/etc/makepkg.conf.d/*.conf" files work with the custo chroot makepkg.conf file.