### PR TITLE
Add Podman support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Create and Publish a Docker image
 on:
   push:
     tags: ["*"]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This adds podman support by making the container come with aurto pre initiated.
Fixes: #89

I have not tested it on docker.
In order to have the repo created on boot of the container a script will run to create the repo db files.
This also removed the --now only for docker.